### PR TITLE
Fix code scanning alert no. 1: Arbitrary file write during tarfile extraction

### DIFF
--- a/jax/experimental/jax2tf/tests/back_compat_tf_test.py
+++ b/jax/experimental/jax2tf/tests/back_compat_tf_test.py
@@ -57,6 +57,9 @@ def deserialize_directory(serialized_string, output_directory):
 
   # Extract the tar archive to the output directory
   with tarfile.open(fileobj=io.BytesIO(tar_data), mode="r") as tar:
+    for entry in tar:
+      if os.path.isabs(entry.name) or ".." in entry.name:
+        raise ValueError("Illegal tar archive entry: " + entry.name)
     tar.extractall(output_directory)
 
 


### PR DESCRIPTION
Fixes [https://github.com/ZoneCog/jax/security/code-scanning/1](https://github.com/ZoneCog/jax/security/code-scanning/1)

To fix the problem, we need to ensure that the file paths within the tar archive do not contain any directory traversal elements such as `..`. This can be done by checking each entry's name before extracting it. If an entry's name contains `..` or is an absolute path, we should raise an error to prevent extraction.

We will modify the `deserialize_directory` function to include this validation step. Specifically, we will:
1. Check if the entry name is an absolute path or contains `..`.
2. Raise a `ValueError` if the entry name is invalid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
